### PR TITLE
Make monitoring configuration extensible

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -9,6 +9,43 @@ return [
 
     'driver' => env('MONITORING_DRIVER', 'mysql'),
 
+    'buffer_size' => (int) env('MONITORING_BUFFER_SIZE', 5),
+
+    'response_macros' => env('MONITORING_RESPONSE_MACROS', true),
+
+    'watchers' => [
+        \RiseTechApps\Monitoring\Watchers\RequestWatcher::class => [
+            'enabled' => true,
+            'options' => [
+                'ignore_http_methods' => [
+                    'options',
+                ],
+                'ignore_status_codes' => [],
+                'ignore_paths' => [
+                    'telescope',
+                    'telescope-api',
+                ],
+            ],
+        ],
+        \RiseTechApps\Monitoring\Watchers\EventWatcher::class => [
+            'enabled' => true,
+            'options' => [
+                'ignore' => [
+                    \RiseTechApps\Monitoring\Watchers\RequestWatcher::class,
+                    \RiseTechApps\Monitoring\Watchers\EventWatcher::class,
+                ],
+            ],
+        ],
+        \RiseTechApps\Monitoring\Watchers\ExceptionWatcher::class => ['enabled' => true],
+        \RiseTechApps\Monitoring\Watchers\CommandWatcher::class => ['enabled' => true],
+        \RiseTechApps\Monitoring\Watchers\GateWatcher::class => ['enabled' => true],
+        \RiseTechApps\Monitoring\Watchers\JobWatcher::class => ['enabled' => true],
+        \RiseTechApps\Monitoring\Watchers\QueueWatcher::class => ['enabled' => true],
+        \RiseTechApps\Monitoring\Watchers\ScheduleWatcher::class => ['enabled' => true],
+        \RiseTechApps\Monitoring\Watchers\NotificationWatcher::class => ['enabled' => true],
+        \RiseTechApps\Monitoring\Watchers\MailWatcher::class => ['enabled' => true],
+    ],
+
     'drivers' => [
         'mysql' => [
             'connection' => env('DB_CONNECTION', 'mysql'),
@@ -18,6 +55,12 @@ return [
         ],
         'http' => [
             'token' => env('MONITORING_HTTP_TOKEN', ''),
+            'endpoint' => env('MONITORING_HTTP_ENDPOINT', 'https://monitoring.app.br/api/logs'),
+            'timeout' => env('MONITORING_HTTP_TIMEOUT', 10),
+            'retry' => [
+                'times' => env('MONITORING_HTTP_RETRY_TIMES', 3),
+                'sleep' => env('MONITORING_HTTP_RETRY_SLEEP', 100),
+            ],
         ],
     ],
 ];

--- a/src/MonitoringServiceProvider.php
+++ b/src/MonitoringServiceProvider.php
@@ -42,14 +42,13 @@ class MonitoringServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'monitoring');
 
         $this->app->bind(MonitoringRepositoryInterface::class, function ($app) {
-            // Passe a conexão desejada aqui
             $driver = config('monitoring.driver');
-            $driversConfig = config("monitoring.drivers");
+            $driversConfig = config('monitoring.drivers', []);
 
             return match ($driver) {
-                'mysql' => new MonitoringRepositoryMysql($driversConfig['mysql']['connection']),
-                'pgsql' => new MonitoringRepositoryPgsql($driversConfig['pgsql']['connection']),
-                'http' => new MonitoringRepositoryHttp($driversConfig['http']['token']),
+                'mysql' => new MonitoringRepositoryMysql($driversConfig['mysql']['connection'] ?? env('DB_CONNECTION', 'mysql')),
+                'pgsql' => new MonitoringRepositoryPgsql($driversConfig['pgsql']['connection'] ?? env('DB_CONNECTION', 'pgsql')),
+                'http' => new MonitoringRepositoryHttp($driversConfig['http'] ?? []),
                 default => throw new \Exception("Driver {$driver} não é suportado.")
             };
         });
@@ -66,7 +65,9 @@ class MonitoringServiceProvider extends ServiceProvider
             return new Device();
         });
 
-        $this->registerMacros();
+        if (config('monitoring.response_macros', true)) {
+            $this->registerMacros();
+        }
     }
 
     protected function registerMacros(): void

--- a/src/Repository/MonitoringRepository.php
+++ b/src/Repository/MonitoringRepository.php
@@ -32,18 +32,53 @@ class MonitoringRepository implements MonitoringRepositoryInterface
         $event = DB::connection($this->connection)->table($this->table)->where('uuid', $id)->first();
 
         if (!$event) {
-            collect([
-                'success' => true,
-                'data' => []
-            ]);
+            return collect();
         }
 
         $relatedEvents = DB::connection($this->connection)->table($this->table)
             ->where('batch_id', $event->batch_id)
-            ->where('id', '!=', $event->id)
+            ->get()
+            ->groupBy('batch_id');
+
+        $batchRelated = $relatedEvents->get($event->batch_id, collect())
+            ->reject(fn($related) => $related->id === $event->id)
+            ->values();
+
+        return collect($this->formatEvent($event, $batchRelated));
+
+    }
+
+    public function getEventsByTypes(string $type): Collection
+    {
+        // Recupera os eventos principais do tipo especificado
+        $events = DB::connection($this->connection)->table($this->table)
+            ->where('type', $type)
             ->get();
 
-        return collect([
+        if ($events->isEmpty()) {
+            return collect();
+        }
+
+        // Coleta os batch_ids únicos dos eventos principais
+        $batchIds = $events->pluck('batch_id')->unique()->values();
+
+        $relatedByBatch = DB::connection($this->connection)->table($this->table)
+            ->whereIn('batch_id', $batchIds)
+            ->get()
+            ->groupBy('batch_id');
+
+        return $events->map(function ($event) use ($relatedByBatch) {
+            $relatedEvents = $relatedByBatch->get($event->batch_id, collect())
+                ->reject(fn($related) => $related->id === $event->id)
+                ->values();
+
+            return $this->formatEvent($event, $relatedEvents);
+        });
+    }
+
+    protected function formatEvent(object $event, Collection $relatedEvents): array
+    {
+        return [
             'id' => $event->id,
             'uuid' => $event->uuid,
             'batch_id' => $event->batch_id,
@@ -63,58 +98,7 @@ class MonitoringRepository implements MonitoringRepositoryInterface
                     'created_at' => $relatedEvent->created_at,
                     'updated_at' => $relatedEvent->updated_at,
                 ];
-            })->toArray()
-        ]);
-
-    }
-
-    public function getEventsByTypes(string $type): Collection
-    {
-        // Recupera os eventos principais do tipo especificado
-        $events = DB::connection($this->connection)->table($this->table)
-            ->where('type', $type)
-            ->get();
-
-        if ($events->isEmpty()) {
-            collect([
-                'success' => true,
-                'data' => []
-            ]);
-        }
-
-        // Coleta os batch_ids únicos dos eventos principais
-        $batchIds = $events->pluck('batch_id')->unique();
-
-        $eventsWithRelated = $events->map(function ($event) use ($batchIds) {
-            $relatedEvents = DB::connection($this->connection)->table($this->table)
-                ->where('batch_id', $event->batch_id)
-                ->where('id', '!=', $event->id)
-                ->get();
-
-            return [
-                'id' => $event->id,
-                'uuid' => $event->uuid,
-                'batch_id' => $event->batch_id,
-                'type' => $event->type,
-                'content' => $event->content,
-                'tags' => $event->tags,
-                'created_at' => $event->created_at,
-                'updated_at' => $event->updated_at,
-                'related_events' => $relatedEvents->map(function ($relatedEvent) {
-                    return [
-                        'id' => $relatedEvent->id,
-                        'uuid' => $relatedEvent->uuid,
-                        'batch_id' => $relatedEvent->batch_id,
-                        'type' => $relatedEvent->type,
-                        'content' => $relatedEvent->content,
-                        'tags' => $relatedEvent->tags,
-                        'created_at' => $relatedEvent->created_at,
-                        'updated_at' => $relatedEvent->updated_at,
-                    ];
-                })->toArray()
-            ];
-        });
-
-        return $eventsWithRelated;
+            })->toArray(),
+        ];
     }
 }

--- a/src/Repository/MonitoringRepositoryPgsql.php
+++ b/src/Repository/MonitoringRepositoryPgsql.php
@@ -51,10 +51,45 @@ class MonitoringRepositoryPgsql  implements MonitoringRepositoryInterface
 
         $relatedEvents = DB::connection($this->connection)->table($this->table)
             ->where('batch_id', $event->batch_id)
-            ->where('id', '!=', $event->id)
+            ->get()
+            ->groupBy('batch_id');
+
+        $batchRelated = $relatedEvents->get($event->batch_id, collect())
+            ->reject(fn($related) => $related->id === $event->id)
+            ->values();
+
+        return collect($this->formatEvent($event, $batchRelated));
+    }
+
+    public function getEventsByTypes(string $type): Collection
+    {
+        $events = DB::connection($this->connection)->table($this->table)
+            ->where('type', $type)
             ->get();
 
-        return collect([
+        if ($events->isEmpty()) {
+            return collect();
+        }
+
+        $batchIds = $events->pluck('batch_id')->unique()->values();
+
+        $relatedByBatch = DB::connection($this->connection)->table($this->table)
+            ->whereIn('batch_id', $batchIds)
+            ->get()
+            ->groupBy('batch_id');
+
+        return $events->map(function ($event) use ($relatedByBatch) {
+            $relatedEvents = $relatedByBatch->get($event->batch_id, collect())
+                ->reject(fn($related) => $related->id === $event->id)
+                ->values();
+
+            return $this->formatEvent($event, $relatedEvents);
+        });
+    }
+
+    protected function formatEvent(object $event, Collection $relatedEvents): array
+    {
+        return [
             'id' => $event->id,
             'uuid' => $event->uuid,
             'batch_id' => $event->batch_id,
@@ -74,51 +109,7 @@ class MonitoringRepositoryPgsql  implements MonitoringRepositoryInterface
                     'created_at' => $relatedEvent->created_at,
                     'updated_at' => $relatedEvent->updated_at,
                 ];
-            })->toArray()
-        ]);
-    }
-
-    public function getEventsByTypes(string $type): Collection
-    {
-        $events = DB::connection($this->connection)->table($this->table)
-            ->where('type', $type)
-            ->get();
-
-        if ($events->isEmpty()) {
-            return collect();
-        }
-
-        $batchIds = $events->pluck('batch_id')->unique();
-
-        $eventsWithRelated = $events->map(function ($event) use ($batchIds) {
-            $relatedEvents = DB::connection($this->connection)->table($this->table)
-                ->where('batch_id', $event->batch_id)
-                ->where('id', '!=', $event->id)
-                ->get();
-
-            return [
-                'id' => $event->id,
-                'uuid' => $event->uuid,
-                'batch_id' => $event->batch_id,
-                'type' => $event->type,
-                'content' => $event->content,
-                'tags' => $event->tags,
-                'created_at' => $event->created_at,
-                'updated_at' => $event->updated_at,
-                'related_events' => $relatedEvents->map(function ($relatedEvent) {
-                    return [
-                        'id' => $relatedEvent->id,
-                        'uuid' => $relatedEvent->uuid,
-                        'batch_id' => $relatedEvent->batch_id,
-                        'type' => $relatedEvent->type,
-                        'content' => $relatedEvent->content,
-                        'tags' => $relatedEvent->tags,
-                        'created_at' => $relatedEvent->created_at,
-                        'updated_at' => $relatedEvent->updated_at,
-                    ];
-                })->toArray()
-            ];
-        });
-        return $eventsWithRelated;
+            })->toArray(),
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- expose watcher settings, buffer size, response macro flag, and HTTP driver options via the package config
- load watcher configuration dynamically in `Monitoring`, honour the buffer-size override, and improve persistence error logging
- refactor the repositories to avoid N+1 queries and hardcoded HTTP settings, adding retries and richer failure logs for the HTTP driver

## Testing
- `php -l config/config.php src/Monitoring.php src/MonitoringServiceProvider.php src/Repository/MonitoringRepository.php src/Repository/MonitoringRepositoryHttp.php src/Repository/MonitoringRepositoryMysql.php src/Repository/MonitoringRepositoryPgsql.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ed4adb708832098722b60a84522e9)